### PR TITLE
Add FastAPI webhook endpoint and container entrypoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Valores de exemplo para execução local ou em contêiner
+VAULT_URL=https://kv-ballx-backend.vault.azure.net/
+BALLX_RPC_URL=
+BALLX_OPERATOR_PK=
+BALLX_AUTHORITY_ADDRESS=
+BALLX_TOKEN_ADDRESS=
+BALLX_RESERVE_ADDRESS=
+WEBHOOK_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENTRYPOINT ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -21,3 +21,62 @@ Instale as dependências:
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\\Scripts\\activate
 pip install -r requirements.txt
+```
+
+---
+
+## 3) Deploy em contêiner (ACR + ACI)
+
+1. **Build** da imagem local:
+   ```bash
+   docker build -t ballx:latest .
+   ```
+2. **Login** e push no Azure Container Registry (ACR):
+   ```bash
+   az acr login -n <registry>
+   docker tag ballx:latest <registry>.azurecr.io/ballx:latest
+   docker push <registry>.azurecr.io/ballx:latest
+   ```
+3. **Executar** no Azure Container Instances (ACI) usando o Key Vault `kv-ballx-backend`:
+   ```bash
+   az container create \
+     -g <resource-group> \
+     -n ballx-distributor \
+     --image <registry>.azurecr.io/ballx:latest \
+     --assign-identity \
+     --environment-variables VAULT_URL=https://kv-ballx-backend.vault.azure.net/ \
+     --secure-environment-variables \
+       BALLX_RPC_URL=<rpc> \
+       BALLX_OPERATOR_PK=<pk> \
+       BALLX_AUTHORITY_ADDRESS=<addr> \
+       BALLX_TOKEN_ADDRESS=<addr> \
+       BALLX_RESERVE_ADDRESS=<addr>
+   ```
+
+   A identidade gerenciada atribuída deve ter permissão **Key Vault Secrets User** no cofre `kv-ballx-backend`.
+
+Um exemplo de variáveis de ambiente necessárias está em `.env.example`.
+
+---
+
+## 4) Receptor de Webhook HTTP
+
+O contêiner expõe um serviço FastAPI na porta **8000** com endpoint `POST /webhook`.
+
+- O WordPress deve enviar um JSON com `wallet` (ou `wallet_address`), `amount`,
+  `tipo` opcional, `reason` opcional e `order_id`.
+- A requisição deve conter o cabeçalho `X-WP-Signature` com o **HMAC SHA256** do corpo usando `WEBHOOK_SECRET`.
+- Variáveis de ambiente:
+  - `WEBHOOK_SECRET` – segredo compartilhado para validar o webhook.
+  - Demais variáveis de blockchain (`BALLX_RPC_URL`, `BALLX_OPERATOR_PK`, etc.).
+
+Exemplo de execução local:
+```bash
+uvicorn app:app --reload
+# então teste:
+curl -X POST http://localhost:8000/webhook \
+  -H "X-WP-Signature: $(printf 'payload' | openssl dgst -sha256 -hmac $WEBHOOK_SECRET -hex | sed 's/^.* //')" \
+  -d '{"wallet":"0x...","amount":10}'
+```
+
+O container em Azure Container Instances deve ter a porta 8000 exposta e receber o `WEBHOOK_SECRET` via Key Vault.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+import json
+import hmac
+import hashlib
+from fastapi import FastAPI, Request, HTTPException
+from web3 import Web3
+from send_ballx_prod import send_ballx, get_secret_reader
+
+app = FastAPI()
+
+HEADER_SIGNATURE = "X-WP-Signature"
+
+
+def verify_signature(body: bytes, header_sig: str, secret: str) -> bool:
+    computed = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(computed, header_sig)
+
+
+@app.post("/webhook")
+async def handle_webhook(request: Request):
+    body = await request.body()
+    header_sig = request.headers.get(HEADER_SIGNATURE)
+    get = get_secret_reader()
+    secret = get("WEBHOOK_SECRET")
+    if not header_sig or not verify_signature(body, header_sig, secret):
+        raise HTTPException(status_code=401, detail="assinatura inválida")
+
+    payload = json.loads(body)
+    wallet = payload.get("wallet") or payload.get("wallet_address")
+    amount = payload.get("amount")
+    if not wallet or not Web3.is_address(wallet):
+        raise HTTPException(status_code=400, detail="carteira inválida")
+    if amount is None:
+        raise HTTPException(status_code=400, detail="amount requerido")
+
+    tipo = payload.get("tipo", "INV")
+    reason = payload.get("reason")
+    idemp = payload.get("order_id") or payload.get("idempotency_key")
+
+    result = send_ballx(wallet, amount, tipo=tipo, reason=reason, idempotency_key=idemp)
+    return result
+
+
+@app.get("/")
+async def healthcheck():
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ web3~=6.14
 azure-identity~=1.16
 azure-keyvault-secrets~=4.9
 python-dotenv~=1.0
+fastapi~=0.110
+uvicorn[standard]~=0.24

--- a/send_ballx_prod.py
+++ b/send_ballx_prod.py
@@ -39,11 +39,10 @@ AUTHORITY_ABI = [
 # ---------- Key Vault ----------
 def get_secret_reader():
     use_kv = os.getenv("BALLX_DISABLE_KV") not in ("1","true","True")
-    vault_url = os.getenv("VAULT_URL")
+    # usa kv-ballx-backend por padrão se VAULT_URL não estiver definido
+    vault_url = os.getenv("VAULT_URL", "https://kv-ballx-backend.vault.azure.net/")
     client = None
     if use_kv:
-        if not vault_url:
-            raise RuntimeError("Defina VAULT_URL para usar Key Vault.")
         cred = DefaultAzureCredential(exclude_interactive_browser_credential=True)
         client = SecretClient(vault_url=vault_url, credential=cred)
     cache = {}
@@ -131,7 +130,18 @@ def mark_processed(key:str, tx_hash:str):
         log.warning(f"Falha ao persistir idempotência: {e}")
 
 # ---------- Core ----------
-def run(args):
+def send_ballx(
+    to: str,
+    amount,
+    *,
+    tipo: str = "INV",
+    reason: Optional[str] = None,
+    human_refid: Optional[str] = None,
+    idempotency_key: Optional[str] = None,
+    wait: bool = False,
+    wait_timeout: int = 180,
+    priority_gwei: int = 40,
+):
     get = get_secret_reader()
     RPC_URL           = get("BALLX_RPC_URL")
     OPERATOR_PK       = get("BALLX_OPERATOR_PK")
@@ -145,13 +155,13 @@ def run(args):
 
     operator = Account.from_key(OPERATOR_PK if OPERATOR_PK.startswith("0x") else "0x"+OPERATOR_PK)
     operator_addr = to_checksum(operator.address)
-    to_addr = to_checksum(args.to)
+    to_addr = to_checksum(to)
 
     token     = w3.eth.contract(address=to_checksum(TOKEN_ADDRESS), abi=ERC20_ABI)
     authority = w3.eth.contract(address=to_checksum(AUTHORITY_ADDRESS), abi=AUTHORITY_ABI)
 
     decimals = token.functions.decimals().call()
-    amount18 = human_to_amount18(args.amount, decimals)
+    amount18 = human_to_amount18(amount, decimals)
 
     reserve_bal = token.functions.balanceOf(to_checksum(RESERVE_ADDRESS)).call()
     allowance   = token.functions.allowance(to_checksum(RESERVE_ADDRESS), to_checksum(AUTHORITY_ADDRESS)).call()
@@ -161,27 +171,26 @@ def run(args):
         raise RuntimeError("Allowance Reserva→Authority insuficiente (faça approve).")
 
     now = now_utc()
-    if args.human_refid:
-        human_ref = args.human_refid.strip()
+    if human_refid:
+        human_ref = human_refid.strip()
     else:
         # refId = TIPO-YYYYMMDDTHHMMSS-last6-XXXX
         nonce4 = f"{int(time.time()*1_000_000)%10000:04d}"
-        human_ref = make_human_refid(args.tipo, to_addr, now, nonce4)
+        human_ref = make_human_refid(tipo, to_addr, now, nonce4)
     if len(human_ref.encode("utf-8")) > 32:
         raise ValueError("human_refid > 32 bytes. Encurte TIPO/format.")
     ref_b32 = to_bytes32_ascii(human_ref)
-    reason  = args.reason or f"{args.tipo} - BALLX"
+    reason  = reason or f"{tipo} - BALLX"
 
     # Idempotência
-    if args.idempotency_key:
-        prev = was_processed(args.idempotency_key)
+    if idempotency_key:
+        prev = was_processed(idempotency_key)
         if prev:
             log.info(f"idempotency-key já processada. tx={prev}")
-            print(json.dumps({"idempotency_key":args.idempotency_key,"tx_hash":prev}, indent=2))
-            return
+            return {"idempotency_key": idempotency_key, "tx_hash": prev}
 
     # Taxas
-    max_fee, prio, gp = suggest_fees(w3, args.priority_gwei)
+    max_fee, prio, gp = suggest_fees(w3, priority_gwei)
     tx_base = {
         "from": operator_addr,
         "nonce": w3.eth.get_transaction_count(operator_addr),
@@ -202,26 +211,44 @@ def run(args):
             signed = w3.eth.account.sign_transaction(tx, OPERATOR_PK if OPERATOR_PK.startswith("0x") else "0x"+OPERATOR_PK)
             tx_hash = w3.eth.send_raw_transaction(signed.rawTransaction).hex()
             log.info(f"tx enviada: {tx_hash} {polygonscan_tx_url(tx_hash)}")
-            if args.idempotency_key:
-                mark_processed(args.idempotency_key, tx_hash)
+            if idempotency_key:
+                mark_processed(idempotency_key, tx_hash)
             result = {
-                "app":APP_NAME,"to":to_addr,"amount18":str(amount18),"decimals":decimals,
-                "human_refid":human_ref,"refid_bytes32":ref_b32,"reason":reason,
-                "tx_hash":tx_hash,"explorer":polygonscan_tx_url(tx_hash),
-                "timestamp":now.isoformat()
+                "app": APP_NAME,
+                "to": to_addr,
+                "amount18": str(amount18),
+                "decimals": decimals,
+                "human_refid": human_ref,
+                "refid_bytes32": ref_b32,
+                "reason": reason,
+                "tx_hash": tx_hash,
+                "explorer": polygonscan_tx_url(tx_hash),
+                "timestamp": now.isoformat(),
             }
-            print(json.dumps(result, ensure_ascii=False, indent=2))
-            if args.wait:
-                rc = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=args.wait_timeout)
-                print(json.dumps({"confirmed": rc.status==1, "blockNumber": rc.blockNumber}, indent=2))
-            return
-        except (ContractLogicError, TimeExhausted) as e:
+            if wait:
+                rc = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=wait_timeout)
+                result["confirmation"] = {"confirmed": rc.status == 1, "blockNumber": rc.blockNumber}
+            return result
+        except (ContractLogicError, TimeExhausted):
             raise
         except Exception as e:
             last_err = e
             log.warning(f"tentativa {i+1}/5 falhou: {e}")
             backoff_sleep(i)
     raise RuntimeError(f"Falha ao enviar transação após retries: {last_err}")
+
+def run(args):
+    return send_ballx(
+        args.to,
+        args.amount,
+        tipo=args.tipo,
+        reason=args.reason,
+        human_refid=args.human_refid,
+        idempotency_key=args.idempotency_key,
+        wait=args.wait,
+        wait_timeout=args.wait_timeout,
+        priority_gwei=args.priority_gwei,
+    )
 
 def parse_args():
     p = argparse.ArgumentParser(description="BALLX • Distribute via Authority (Key Vault + Prod)")
@@ -238,4 +265,5 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    run(args)
+    result = run(args)
+    print(json.dumps(result, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## Summary
- expose `send_ballx` as reusable function and add FastAPI webhook that triggers token distribution
- container now runs `uvicorn app:app` and includes FastAPI/uvicorn dependencies
- document environment variables and webhook usage

## Testing
- `python -m py_compile send_ballx_prod.py app.py`
- `python send_ballx_prod.py --help` *(fails: ModuleNotFoundError: No module named 'web3')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement web3~=6.14)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3c2d7664832584dacad8d92a0dec